### PR TITLE
Task 9: GLL-based CFPQ algorithm

### DIFF
--- a/project/task3.py
+++ b/project/task3.py
@@ -2,6 +2,7 @@ from typing import Iterable
 from networkx import MultiDiGraph
 from pyformlang.finite_automaton import State, Symbol, NondeterministicFiniteAutomaton
 from scipy.sparse import identity, kron, csr_matrix
+import scipy.sparse as scsp
 
 from project.task2 import regex_to_dfa, graph_to_nfa
 
@@ -13,7 +14,8 @@ class AdjacencyMatrixFA:
     start_states: set[State]
     final_states: set[State]
     labels: set[Symbol]
-    boolean_decompress: dict[Symbol, csr_matrix]
+    boolean_decompress: dict[Symbol, scsp.spmatrix]
+    matrix_format: str
 
     def _print_boolean_decompress_pretty(self):
         for symbol in self.boolean_decompress:
@@ -24,9 +26,12 @@ class AdjacencyMatrixFA:
         self,
         fa: NondeterministicFiniteAutomaton,
         index_mapping: (tuple[dict[State, int], dict[int, State]] | None) = None,
+        matrix_format: str = "csr",
     ):
         self.states = fa.states
         self.labels = fa.symbols
+        self.matrix_format = matrix_format
+        matrix_ctor = getattr(scsp, f"{self.matrix_format}_matrix", csr_matrix)
 
         # for DFA: casting it to NFA
         if not (isinstance(fa.start_states, set)):
@@ -76,11 +81,12 @@ class AdjacencyMatrixFA:
         self.boolean_decompress = dict()
         for symbol in boolean_dec_dict:
             arr = boolean_dec_dict.get(symbol)
-            mat = csr_matrix(arr)
+            mat = matrix_ctor(arr)
             self.boolean_decompress.update({symbol: mat})
 
-    def get_trans_closure(self) -> csr_matrix:
-        E = identity(len(self.states), format="csr", dtype="bool")
+    # cover the return with matrix_ctor?
+    def get_trans_closure(self) -> scsp.spmatrix:
+        E = identity(len(self.states), format=self.matrix_format, dtype="bool")
         sum_m = E
         for symbol in self.boolean_decompress:
             mat = self.boolean_decompress.get(symbol)
@@ -135,7 +141,8 @@ def build_AdjMatrixFA_with_artefacts(
     final_states: set[State],
     index_of_state: dict[State, int],
     state_of_index: dict[int, State],
-    bool_dec: dict[Symbol, csr_matrix],
+    bool_dec: dict[Symbol, scsp.spmatrix],
+    matrix_format: str = "csr",
 ) -> AdjacencyMatrixFA:
     nfa = NondeterministicFiniteAutomaton(
         states=states, start_state=start_states, final_states=final_states
@@ -146,7 +153,9 @@ def build_AdjMatrixFA_with_artefacts(
             for snd_state in states:
                 if mat[index_of_state.get(fst_state), index_of_state.get(snd_state)]:
                     nfa.add_transition(fst_state, symbol, snd_state)
-    mat = AdjacencyMatrixFA(nfa, index_mapping=(index_of_state, state_of_index))
+    mat = AdjacencyMatrixFA(
+        nfa, index_mapping=(index_of_state, state_of_index), matrix_format=matrix_format
+    )
     return mat
 
 
@@ -184,7 +193,7 @@ def intersect_automata(
     for symbol in shared_labels:
         fst_bool_dec = automaton1.boolean_decompress.get(symbol)
         snd_bool_dec = automaton2.boolean_decompress.get(symbol)
-        intersection = kron(fst_bool_dec, snd_bool_dec, format="csr")
+        intersection = kron(fst_bool_dec, snd_bool_dec, format=automaton1.matrix_format)
         new_bool_dec.update({symbol: intersection})
 
     return build_AdjMatrixFA_with_artefacts(
@@ -194,15 +203,22 @@ def intersect_automata(
         intersection_idxes,
         intersection_states_of_idx,
         new_bool_dec,
+        matrix_format=automaton1.matrix_format,
     )
 
 
 def tensor_based_rpq(
-    regex: str, graph: MultiDiGraph, start_nodes: set[int], final_nodes: set[int]
+    regex: str,
+    graph: MultiDiGraph,
+    start_nodes: set[int],
+    final_nodes: set[int],
+    matrix_format: str = "csr",
 ) -> set[tuple[int, int]]:
     reg_graph = regex_to_dfa(regex)
-    aut1 = AdjacencyMatrixFA(reg_graph)
-    aut2 = AdjacencyMatrixFA(graph_to_nfa(graph, start_nodes, final_nodes))
+    aut1 = AdjacencyMatrixFA(reg_graph, matrix_format=matrix_format)
+    aut2 = AdjacencyMatrixFA(
+        graph_to_nfa(graph, start_nodes, final_nodes), matrix_format=matrix_format
+    )
 
     intersection = intersect_automata(aut1, aut2)
     ind_of_st = intersection.index_of_state

--- a/project/task6.py
+++ b/project/task6.py
@@ -1,0 +1,87 @@
+from pyformlang.cfg import Production, Variable, Terminal, CFG, Epsilon
+from networkx import DiGraph
+from collections import defaultdict
+
+
+def cfg_to_weak_normal_form(cfg: CFG) -> CFG:
+    eps_rules = set()
+    for nonterm in cfg.get_nullable_symbols():
+        eps_rules.add(Production(nonterm, [Epsilon()]))
+    cfg = cfg.to_normal_form()
+    cfg = CFG(
+        cfg.variables, cfg.terminals, cfg.start_symbol, cfg.productions | eps_rules
+    )
+
+    return cfg.remove_useless_symbols()
+
+
+# for rules of types (A -> a) and (Ni -> Eps)
+def _hellings_terminal_rules(
+    cfg: CFG, graph: DiGraph
+) -> set[tuple[int, Variable, int]]:
+    term_to_nonterm = defaultdict(list)
+    for rule in cfg.productions:
+        if len(rule.body) > 0 and isinstance(rule.body[0], Terminal):
+            term_to_nonterm[rule.body[0].value].append(rule.head)
+
+    new_edges = set()
+    for fst, snd, lbl in graph.edges(data="label"):
+        if term_to_nonterm.get(lbl) is not None:
+            for nonterm in term_to_nonterm.get(lbl):
+                new_edges.add((fst, nonterm, snd))
+
+    eps_nonterms = cfg.get_nullable_symbols()
+    for node in graph.nodes:
+        for nonterm in eps_nonterms:
+            new_edges.add((node, nonterm, node))
+    return new_edges
+
+
+def _hellings_nonterminal_rules(
+    cfg: CFG, edges: set[tuple[int, Variable, int]]
+) -> set[tuple[int, Variable, int]]:
+    two_nonterm_rules = []
+    for rule in cfg.productions:
+        if len(rule.body) == 2:
+            two_nonterm_rules.append(rule)
+
+    edges_are_added = True
+    while edges_are_added:
+        edges_are_added = False
+        added_edges = set()
+        for fst1, N1, snd1 in edges:
+            for fst2, N2, snd2 in edges:
+                if snd1 == fst2:
+                    for rule in two_nonterm_rules:
+                        if (
+                            N1 == rule.body[0]
+                            and N2 == rule.body[1]
+                            and (fst1, rule.head, snd2) not in edges
+                        ):
+                            added_edges.add((fst1, rule.head, snd2))
+        if added_edges:
+            edges_are_added = True
+            edges = edges | added_edges
+    return edges
+
+
+def hellings_based_cfpq(
+    cfg: CFG,
+    graph: DiGraph,
+    start_nodes: set[int] = None,
+    final_nodes: set[int] = None,
+) -> set[tuple[int, int]]:
+    cfg_wnf = cfg_to_weak_normal_form(cfg)
+    new_edges = _hellings_terminal_rules(cfg_wnf, graph)
+    new_edges = _hellings_nonterminal_rules(cfg_wnf, new_edges)
+
+    if start_nodes is None:
+        start_nodes = graph.nodes
+    if final_nodes is None:
+        final_nodes = graph.nodes
+
+    res = set()
+    for fst, var, snd in new_edges:
+        if var == cfg_wnf.start_symbol and fst in start_nodes and snd in final_nodes:
+            res.add((fst, snd))
+    return res

--- a/project/task7.py
+++ b/project/task7.py
@@ -1,0 +1,99 @@
+from collections import defaultdict
+import networkx as nx
+from pyparsing import Any, Set
+import scipy.sparse as scsp
+from pyformlang.cfg import Variable, Terminal, CFG
+from project.task6 import cfg_to_weak_normal_form
+
+
+def _matrix_terminal_rules(
+    cfg: CFG,
+    graph: nx.DiGraph,
+    bool_dec: dict[Variable, scsp.spmatrix],
+    index_of_node: dict[Any, int],
+) -> dict[Variable, scsp.spmatrix]:
+    term_to_nonterm = defaultdict(list)
+    for rule in cfg.productions:
+        if len(rule.body) > 0 and isinstance(rule.body[0], Terminal):
+            term_to_nonterm[rule.body[0].value].append(rule.head)
+
+    for fst, snd, lbl in graph.edges(data="label"):
+        if term_to_nonterm.get(lbl):
+            for nonterm in term_to_nonterm.get(lbl):
+                cur_m = bool_dec.get(nonterm)
+                cur_m[index_of_node[fst], index_of_node[snd]] = True
+
+    eps_nonterms = cfg.get_nullable_symbols()
+    for nonterm in eps_nonterms:
+        cur_m = bool_dec.get(nonterm)
+        for node in graph.nodes:
+            cur_m[index_of_node[node], index_of_node[node]] = True
+    return bool_dec
+
+
+def _matrix_nonterminal_rules(
+    cfg: CFG,
+    bool_dec: dict[Variable, scsp.spmatrix],
+) -> dict[Variable, scsp.spmatrix]:
+    body_of_head = dict()
+    var_to_its_body_rules = defaultdict(list)
+    changed_nonterms = []
+    for rule in cfg.productions:
+        if len(rule.body) == 2:
+            body_of_head.update({rule.head: rule.body})
+            var_to_its_body_rules[rule.body[0]].append(rule)
+            var_to_its_body_rules[rule.body[1]].append(rule)
+        # if length of body < 2, then this rule is either A -> a or Ni -> eps
+        elif len(rule.body) == 1:
+            changed_nonterms.append(rule.head)
+
+    while changed_nonterms:
+        cur_nonterm = changed_nonterms.pop()
+        if var_to_its_body_rules.get(cur_nonterm):
+            for rule in var_to_its_body_rules.get(cur_nonterm):
+                mat_nonterm_new = bool_dec.get(rule.body[0]) @ bool_dec.get(
+                    rule.body[1]
+                )
+                mat_nonterm = bool_dec.get(rule.head)
+                mat_nonterm_new += mat_nonterm
+                if (mat_nonterm < mat_nonterm_new).toarray().any():
+                    changed_nonterms.append(rule.head)
+                    bool_dec.update({rule.head: mat_nonterm_new})
+    return bool_dec
+
+
+def matrix_based_cfpq(
+    cfg: CFG,
+    graph: nx.DiGraph,
+    start_nodes: Set[int] = None,
+    final_nodes: Set[int] = None,
+    matrix_format="csr",
+) -> set[tuple[int, int]]:
+    cfg_wnf = cfg_to_weak_normal_form(cfg)
+    enum_nodes = list(enumerate(graph.nodes))
+    index_of_node = {node: index for index, node in enum_nodes}
+    node_of_index = {index: node for index, node in enum_nodes}
+
+    matrix_ctor = getattr(scsp, f"{matrix_format}_matrix", scsp.csr_matrix)
+    bool_dec = dict()
+    size = len(graph.nodes)
+    for nonterm in cfg_wnf.variables:
+        bool_dec.update({nonterm: matrix_ctor((size, size), dtype="bool")})
+
+    bool_dec = _matrix_terminal_rules(cfg_wnf, graph, bool_dec, index_of_node)
+    bool_dec = _matrix_nonterminal_rules(cfg_wnf, bool_dec)
+
+    if start_nodes is None:
+        start_nodes = graph.nodes
+    if final_nodes is None:
+        final_nodes = graph.nodes
+
+    res = set()
+    for fst, snd in zip(*bool_dec.get(cfg_wnf.start_symbol).nonzero()):
+        if (
+            node_of_index.get(fst) in start_nodes
+            and node_of_index.get(snd) in final_nodes
+        ):
+            res.add((node_of_index.get(fst), node_of_index.get(snd)))
+
+    return res

--- a/project/task7.py
+++ b/project/task7.py
@@ -35,12 +35,10 @@ def _matrix_nonterminal_rules(
     cfg: CFG,
     bool_dec: dict[Variable, scsp.spmatrix],
 ) -> dict[Variable, scsp.spmatrix]:
-    body_of_head = dict()
     var_to_its_body_rules = defaultdict(list)
     changed_nonterms = []
     for rule in cfg.productions:
         if len(rule.body) == 2:
-            body_of_head.update({rule.head: rule.body})
             var_to_its_body_rules[rule.body[0]].append(rule)
             var_to_its_body_rules[rule.body[1]].append(rule)
         # if length of body < 2, then this rule is either A -> a or Ni -> eps

--- a/project/task8.py
+++ b/project/task8.py
@@ -6,11 +6,14 @@ import scipy.sparse as scsp
 from project.task2 import graph_to_nfa
 from project.task3 import AdjacencyMatrixFA, intersect_automata
 
+
 def cfg_to_rsm(cfg: CFG) -> RecursiveAutomaton:
     return RecursiveAutomaton.from_text(cfg.to_text())
 
+
 def ebnf_to_rsm(ebnf: str) -> RecursiveAutomaton:
-  return RecursiveAutomaton.from_text(ebnf)
+    return RecursiveAutomaton.from_text(ebnf)
+
 
 def _build_rsm_fa(rsm: RecursiveAutomaton) -> NondeterministicFiniteAutomaton:
     rsm_trans = []
@@ -25,9 +28,12 @@ def _build_rsm_fa(rsm: RecursiveAutomaton) -> NondeterministicFiniteAutomaton:
         for st in box.final_states:
             rsm_fin.add(State((sym, st.value)))
 
-    rsm_fa = NondeterministicFiniteAutomaton(start_state=rsm_start, final_states=rsm_fin)
+    rsm_fa = NondeterministicFiniteAutomaton(
+        start_state=rsm_start, final_states=rsm_fin
+    )
     rsm_fa.add_transitions(rsm_trans)
     return rsm_fa
+
 
 def _ms_bfs_with_paths(intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrixFA):
     n = len(intersection.states)
@@ -72,8 +78,11 @@ def _ms_bfs_with_paths(intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrix
 
     return reachability, edge_usage
 
+
 # MSBFS should search all paths from RSM-start to RSM-fin, regardless of graph start and end vertices
-def _define_start_states(intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrixFA) -> set[State]:
+def _define_start_states(
+    intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrixFA
+) -> set[State]:
     rsm_starts = adj_rsm.start_states
     res = []
     for st in intersection.states:
@@ -83,7 +92,13 @@ def _define_start_states(intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatr
     return res
 
 
-def _add_nonterms(reachability: scsp.spmatrix, adj_graph: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrixFA, intersection: AdjacencyMatrixFA, edges) -> tuple[AdjacencyMatrixFA, bool]:
+def _add_nonterms(
+    reachability: scsp.spmatrix,
+    adj_graph: AdjacencyMatrixFA,
+    adj_rsm: AdjacencyMatrixFA,
+    intersection: AdjacencyMatrixFA,
+    edges,
+) -> tuple[AdjacencyMatrixFA, bool]:
     new_nonterm_added = False
     rows, cols = reachability.nonzero()
     for i, j in zip(rows, cols):
@@ -91,33 +106,45 @@ def _add_nonterms(reachability: scsp.spmatrix, adj_graph: AdjacencyMatrixFA, adj
         gr_fin, rsm_fin = intersection.state_of_index.get(j).value
         start_rsm_box, _ = rsm_start.value
         fin_rsm_box, _ = rsm_fin.value
-        if start_rsm_box == fin_rsm_box and rsm_start in adj_rsm.start_states and rsm_fin in adj_rsm.final_states:
+        if (
+            start_rsm_box == fin_rsm_box
+            and rsm_start in adj_rsm.start_states
+            and rsm_fin in adj_rsm.final_states
+        ):
             if not start_rsm_box in adj_graph.boolean_decompress:
                 n = len(adj_graph.states)
-                matrix_ctor = getattr(scsp, f"{adj_graph.matrix_format}_matrix", scsp.csr_matrix)
+                matrix_ctor = getattr(
+                    scsp, f"{adj_graph.matrix_format}_matrix", scsp.csr_matrix
+                )
                 new_nonterm_added = True
                 nonterm_mat = matrix_ctor((n, n), dtype=bool)
-                nonterm_mat[adj_graph.index_of_state.get(gr_start), adj_graph.index_of_state.get(gr_fin)] = True
+                nonterm_mat[
+                    adj_graph.index_of_state.get(gr_start),
+                    adj_graph.index_of_state.get(gr_fin),
+                ] = True
                 adj_graph.boolean_decompress.update({start_rsm_box: nonterm_mat})
                 adj_graph.labels.add(start_rsm_box)
             else:
                 nonterm_mat = adj_graph.boolean_decompress.get(start_rsm_box)
-                if not nonterm_mat[adj_graph.index_of_state.get(gr_start), adj_graph.index_of_state.get(gr_fin)]:
+                if not nonterm_mat[
+                    adj_graph.index_of_state.get(gr_start),
+                    adj_graph.index_of_state.get(gr_fin),
+                ]:
                     new_nonterm_added = True
-                    nonterm_mat[adj_graph.index_of_state.get(gr_start), adj_graph.index_of_state.get(gr_fin)] = True
+                    nonterm_mat[
+                        adj_graph.index_of_state.get(gr_start),
+                        adj_graph.index_of_state.get(gr_fin),
+                    ] = True
                     adj_graph.boolean_decompress.update({start_rsm_box: nonterm_mat})
     return (adj_graph, new_nonterm_added)
 
 
-
-
-
 def tensor_based_cfpq(
-  rsm: RecursiveAutomaton,
-  graph: nx.DiGraph,
-  start_nodes: set[int] = None,
-  final_nodes: set[int] = None,
-  matrix_format="csr",
+    rsm: RecursiveAutomaton,
+    graph: nx.DiGraph,
+    start_nodes: set[int] = None,
+    final_nodes: set[int] = None,
+    matrix_format="csr",
 ) -> set[tuple[int, int]]:
     matrix_ctor = getattr(scsp, f"{matrix_format}_matrix", scsp.csr_matrix)
     if start_nodes is None:
@@ -130,13 +157,16 @@ def tensor_based_cfpq(
     fa_rsm = _build_rsm_fa(rsm)
     adj_rsm = AdjacencyMatrixFA(fa_rsm, matrix_format=matrix_format)
 
-
     info_added = True
     while info_added:
         info_added = False
         intersection = intersect_automata(adj_graph, adj_rsm)
-        reachability, edges_reachable_from_start = _ms_bfs_with_paths(intersection, adj_rsm)
-        adj_graph, info_added = _add_nonterms(reachability, adj_graph, adj_rsm, intersection, edges_reachable_from_start)
+        reachability, edges_reachable_from_start = _ms_bfs_with_paths(
+            intersection, adj_rsm
+        )
+        adj_graph, info_added = _add_nonterms(
+            reachability, adj_graph, adj_rsm, intersection, edges_reachable_from_start
+        )
 
     res = set()
     if rsm.initial_label in adj_graph.boolean_decompress:

--- a/project/task8.py
+++ b/project/task8.py
@@ -1,0 +1,302 @@
+from collections import defaultdict
+from networkx import MultiDiGraph
+from pyformlang.cfg import Variable, Terminal, CFG, Production, Epsilon
+from pyformlang.rsa import RecursiveAutomaton, Box
+from pyformlang.finite_automaton import State, Symbol, NondeterministicFiniteAutomaton
+import matplotlib.pyplot as plt
+import networkx as nx
+import scipy.sparse as scsp
+import scipy as sc
+from project.task2 import graph_to_nfa
+from project.task3 import AdjacencyMatrixFA, intersect_automata
+
+def cfg_to_rsm(cfg: CFG) -> RecursiveAutomaton:
+    #print(cfg.to_text())
+    return RecursiveAutomaton.from_text(cfg.to_text())
+
+def ebnf_to_rsm(ebnf: str) -> RecursiveAutomaton:
+  return RecursiveAutomaton.from_text(ebnf)
+
+def _build_rsm_fa(rsm: RecursiveAutomaton) -> NondeterministicFiniteAutomaton:
+    rsm_trans = []
+    rsm_start = set()
+    rsm_fin = set()
+    for sym in rsm.boxes:
+        box: Box = rsm.get_box(sym)
+        for fst_st, snd_st, lbl in box.dfa.to_networkx().edges(data="label"):
+            rsm_trans.append((State((sym, fst_st)), lbl, State((sym, snd_st))))
+        for st in box.start_state:
+            rsm_start.add(State((sym, st.value)))
+        for st in box.final_states:
+            rsm_fin.add(State((sym, st.value)))
+
+    rsm_fa = NondeterministicFiniteAutomaton(start_state=rsm_start, final_states=rsm_fin)
+    rsm_fa.add_transitions(rsm_trans)
+    return rsm_fa
+
+def _ms_bfs_with_paths(intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrixFA):
+    n = len(intersection.states)
+    matrix_ctor = getattr(scsp, f"{intersection.matrix_format}_matrix", scsp.csr_matrix)
+
+    bool_dec = intersection.boolean_decompress
+    #intersection._print_boolean_decompress_pretty()
+    for sym in bool_dec:
+        mat = bool_dec.get(sym)
+        rows, cols = mat.nonzero()
+        for i, j in zip(rows, cols):
+            #print(f"Non-zero elems of intersection with symbol {sym}")
+            s = intersection.state_of_index.get(i)
+            f = intersection.state_of_index.get(j)
+            #print(f"{s} {f}")
+
+    # represents start vertices
+    reachability = matrix_ctor((n, n), dtype=bool)
+    start_st = _define_start_states(intersection, adj_rsm)
+    for s in start_st:
+        i = intersection.index_of_state[s]
+        reachability[i, i] = True
+
+    #print(reachability.toarray() * 1)
+    edge_usage = []
+
+    finished = False
+    while not finished:
+        finished = True
+        for sym, mat in bool_dec.items():
+            sym_reach = reachability @ mat
+            new_edges = sym_reach > reachability
+            #print(sym)
+            #print(sym_reach.toarray() * 1)
+            if new_edges.count_nonzero() > 0:
+                reachability = reachability + sym_reach
+                finished = False
+
+                rows, cols = new_edges.nonzero()
+                for i, j in zip(rows, cols):
+                    s_from = intersection.state_of_index[i]
+                    s_to = intersection.state_of_index[j]
+                    edge_usage.append((s_from, sym, s_to))
+
+    #print(reachability.toarray() * 1)
+    rows, cols = reachability.nonzero()
+    for i, j in zip(rows, cols):
+        s = intersection.state_of_index.get(i)
+        f = intersection.state_of_index.get(j)
+        #print(f"{s} {f}")
+    #print(f"edge_usage is {edge_usage}")
+
+    return reachability, edge_usage
+
+# MSBFS should search all paths from RSM-start to RSM-fin, regardless of graph start and end vertices
+def _define_start_states(intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrixFA) -> set[State]:
+    rsm_starts = adj_rsm.start_states
+    res = []
+    for st in intersection.states:
+        _, rsm_st = st.value
+        if rsm_st in rsm_starts:
+            res.append(st)
+    return res
+
+
+def _add_nonterms(reachability: scsp.spmatrix, adj_graph: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrixFA, intersection: AdjacencyMatrixFA, edges) -> tuple[AdjacencyMatrixFA, bool]:
+    new_nonterm_added = False
+    rows, cols = reachability.nonzero()
+    for i, j in zip(rows, cols):
+        gr_start, rsm_start = intersection.state_of_index.get(i).value
+        gr_fin, rsm_fin = intersection.state_of_index.get(j).value
+        #print(f"{gr_start} {rsm_start} {gr_fin} {rsm_fin}")
+        start_rsm_box, _ = rsm_start.value
+        fin_rsm_box, _ = rsm_fin.value
+        if start_rsm_box == fin_rsm_box and rsm_start in adj_rsm.start_states and rsm_fin in adj_rsm.final_states:
+            #print(f"{gr_start} {rsm_start} {gr_fin} {rsm_fin}")
+            '''
+            if ((gr_start, rsm_start), start_rsm_box, (gr_fin, rsm_fin)) not in edges:
+                print("IM NOT HERE")
+                continue'''
+            if not start_rsm_box in adj_graph.boolean_decompress:
+                n = len(adj_graph.states)
+                matrix_ctor = getattr(scsp, f"{adj_graph.matrix_format}_matrix", scsp.csr_matrix)
+                new_nonterm_added = True
+                nonterm_mat = matrix_ctor((n, n), dtype=bool)
+                nonterm_mat[adj_graph.index_of_state.get(gr_start), adj_graph.index_of_state.get(gr_fin)] = True
+                #print(f" I PUT THIS IN MAT {gr_start} {rsm_start} {gr_fin} {rsm_fin}")
+                adj_graph.boolean_decompress.update({start_rsm_box: nonterm_mat})
+                adj_graph.labels.add(start_rsm_box)
+            else:
+                nonterm_mat = adj_graph.boolean_decompress.get(start_rsm_box)
+                if not nonterm_mat[adj_graph.index_of_state.get(gr_start), adj_graph.index_of_state.get(gr_fin)]:
+                    new_nonterm_added = True
+                    nonterm_mat[adj_graph.index_of_state.get(gr_start), adj_graph.index_of_state.get(gr_fin)] = True
+                    #print(f" I PUT THIS IN MAT {gr_start} {rsm_start} {gr_fin} {rsm_fin}")
+                    adj_graph.boolean_decompress.update({start_rsm_box: nonterm_mat})
+    return (adj_graph, new_nonterm_added)
+
+
+
+
+
+def tensor_based_cfpq(
+  rsm: RecursiveAutomaton,
+  graph: nx.DiGraph,
+  start_nodes: set[int] = None,
+  final_nodes: set[int] = None,
+  matrix_format="csr",
+) -> set[tuple[int, int]]:
+    matrix_ctor = getattr(scsp, f"{matrix_format}_matrix", scsp.csr_matrix)
+    # maybe change it to "if start_nodes is None or s in start_nodes" in last if?
+    if start_nodes is None:
+        start_nodes = graph.nodes
+    if final_nodes is None:
+        final_nodes = graph.nodes
+
+    # add nullable symbols into graph
+    '''for sym in rsm.boxes:
+        box: Box = rsm.get_box(sym)
+        if box.start_state.issubset(box.final_states):
+            print(f"{sym} IS NULL")
+            for node in graph.nodes:
+                graph.add_edge(node, node, label=sym)'''
+
+    fa_graph = graph_to_nfa(graph, start_nodes, final_nodes)
+    adj_graph = AdjacencyMatrixFA(fa_graph, matrix_format=matrix_format)
+    #print("BOOL DEC BEFORE ALGO")
+    #adj_graph._print_boolean_decompress_pretty()
+    fa_rsm = _build_rsm_fa(rsm)
+    #print(fa_rsm._transition_function.to_dict())
+    adj_rsm = AdjacencyMatrixFA(fa_rsm, matrix_format=matrix_format)
+    #print(adj_rsm.start_states)
+    #print(adj_rsm.final_states)
+
+
+    info_added = True
+    while info_added:
+        info_added = False
+        intersection = intersect_automata(adj_graph, adj_rsm)
+        #print(adj_rsm.labels)
+        #print(intersection.labels)
+        #intersection._print_boolean_decompress_pretty()
+        reachability, edges_reachable_from_start = _ms_bfs_with_paths(intersection, adj_rsm)
+        adj_graph, info_added = _add_nonterms(reachability, adj_graph, adj_rsm, intersection, edges_reachable_from_start)
+        #adj_graph._print_boolean_decompress_pretty()
+        #adj_graph._print_boolean_decompress_pretty()
+        #print(edges_reachable_from_start)
+        '''for fst, lbl, snd in edges_reachable_from_start:
+            bool_dec_mat = adj_graph.boolean_decompress.get(lbl)
+            fst_gr, _ = fst.value
+            snd_gr, _ = snd.value
+            if not bool_dec_mat[adj_graph.index_of_state.get(fst_gr), adj_graph.index_of_state.get(snd_gr)]:
+                # TODO: on  example, maybe S shouldnt be there?
+                # TODO: maybe check if all vertices are in start->end path?
+                #print(f"{fst} {lbl} {snd}")
+                bool_dec_mat[adj_graph.index_of_state.get(fst_gr), adj_graph.index_of_state.get(snd_gr)] = True
+                info_added = True'''
+
+
+
+    res = set()
+    if rsm.initial_label in adj_graph.boolean_decompress:
+        mat = adj_graph.boolean_decompress.get(rsm.initial_label)
+        rows, cols = mat.nonzero()
+        for i, j in zip(rows, cols):
+            s = adj_graph.state_of_index.get(i)
+            f = adj_graph.state_of_index.get(j)
+            if (s in start_nodes) and (f in final_nodes):
+                res.add((s, f))
+    #print(f"res is {res}")
+    return res
+
+
+
+
+
+
+'''
+cfg = CFG.from_text("S -> a S b | a b")
+baa_graph = MultiDiGraph()
+baa_graph.add_edges_from(
+    [(0, 0, {"label": "b"}), (0, 1, {"label": "a"}), (1, 0, {"label": "a"})]
+)
+res = cfg_to_rsm(cfg)
+
+res_tensor = tensor_based_cfpq(res, baa_graph)
+print(res_tensor)
+
+box: Box = res.get_box("S")
+edges = box.dfa.minimize().to_networkx().edges(data="label")
+s_graph = box.dfa.minimize().to_networkx()
+
+edge_labels = defaultdict(list)
+for u, v, data in s_graph.edges(data=True):
+    if 'label' in data:
+        edge_labels[(u, v)].append(data['label'])
+edge_labels_combined = {}
+for (u, v), labels in edge_labels.items():
+    edge_labels_combined[(u, v)] = ', '.join(map(str, labels))
+pos = nx.spring_layout(s_graph)
+plt.figure(figsize=(12, 8))
+nx.draw(s_graph, pos, with_labels=True,
+        node_color='lightblue',
+        node_size=500,
+        font_size=10,
+        font_weight='bold',
+        arrows=True,
+        edge_color='gray')
+nx.draw_networkx_edge_labels(s_graph, pos, edge_labels=edge_labels_combined)
+plt.show()
+'''
+
+'''
+# Creation of variables
+var_S = Variable("S")
+
+# Creation of terminals
+ter_a = Terminal("a")
+ter_b = Terminal("b")
+eps = Epsilon()
+
+# Creation of productions
+p0 = Production(var_S, [eps])
+p1 = Production(var_S, [ter_a, var_S, ter_b])
+p2 = Production(var_S, [var_S, var_S])
+
+
+# Creation of the CFG
+cfg = CFG(
+    {var_S}, {ter_a, ter_b}, var_S, {p0, p1, p2}
+)
+#print(cfg.to_text())
+
+# Creation of graph
+graph = nx.MultiDiGraph()
+graph.add_edge(1, 0, label="a")  # 1 -a-> 0
+graph.add_edge(0, 1, label="a")  # 0 -a-> 1
+graph.add_edge(0, 0, label="b")  # 0 -b-> 0
+
+res = cfg_to_rsm(cfg)
+
+res_tensor = tensor_based_cfpq(res, graph, {1}, {0, 1})
+print(res_tensor)
+
+box: Box = res.get_box(var_S)
+edges = box.dfa.minimize().to_networkx().edges(data="label")
+s_graph = box.dfa.minimize().to_networkx()
+
+edge_labels = defaultdict(list)
+for u, v, data in s_graph.edges(data=True):
+    if 'label' in data:
+        edge_labels[(u, v)].append(data['label'])
+edge_labels_combined = {}
+for (u, v), labels in edge_labels.items():
+    edge_labels_combined[(u, v)] = ', '.join(map(str, labels))
+pos = nx.spring_layout(s_graph)
+plt.figure(figsize=(12, 8))
+nx.draw(s_graph, pos, with_labels=True,
+        node_color='lightblue',
+        node_size=500,
+        font_size=10,
+        font_weight='bold',
+        arrows=True,
+        edge_color='gray')
+nx.draw_networkx_edge_labels(s_graph, pos, edge_labels=edge_labels_combined)
+plt.show()
+'''

--- a/project/task8.py
+++ b/project/task8.py
@@ -1,17 +1,12 @@
-from collections import defaultdict
-from networkx import MultiDiGraph
-from pyformlang.cfg import Variable, Terminal, CFG, Production, Epsilon
+from pyformlang.cfg import CFG
 from pyformlang.rsa import RecursiveAutomaton, Box
-from pyformlang.finite_automaton import State, Symbol, NondeterministicFiniteAutomaton
-import matplotlib.pyplot as plt
+from pyformlang.finite_automaton import State, NondeterministicFiniteAutomaton
 import networkx as nx
 import scipy.sparse as scsp
-import scipy as sc
 from project.task2 import graph_to_nfa
 from project.task3 import AdjacencyMatrixFA, intersect_automata
 
 def cfg_to_rsm(cfg: CFG) -> RecursiveAutomaton:
-    #print(cfg.to_text())
     return RecursiveAutomaton.from_text(cfg.to_text())
 
 def ebnf_to_rsm(ebnf: str) -> RecursiveAutomaton:
@@ -39,24 +34,19 @@ def _ms_bfs_with_paths(intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrix
     matrix_ctor = getattr(scsp, f"{intersection.matrix_format}_matrix", scsp.csr_matrix)
 
     bool_dec = intersection.boolean_decompress
-    #intersection._print_boolean_decompress_pretty()
     for sym in bool_dec:
         mat = bool_dec.get(sym)
         rows, cols = mat.nonzero()
         for i, j in zip(rows, cols):
-            #print(f"Non-zero elems of intersection with symbol {sym}")
             s = intersection.state_of_index.get(i)
             f = intersection.state_of_index.get(j)
-            #print(f"{s} {f}")
 
-    # represents start vertices
     reachability = matrix_ctor((n, n), dtype=bool)
     start_st = _define_start_states(intersection, adj_rsm)
     for s in start_st:
         i = intersection.index_of_state[s]
         reachability[i, i] = True
 
-    #print(reachability.toarray() * 1)
     edge_usage = []
 
     finished = False
@@ -65,8 +55,6 @@ def _ms_bfs_with_paths(intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrix
         for sym, mat in bool_dec.items():
             sym_reach = reachability @ mat
             new_edges = sym_reach > reachability
-            #print(sym)
-            #print(sym_reach.toarray() * 1)
             if new_edges.count_nonzero() > 0:
                 reachability = reachability + sym_reach
                 finished = False
@@ -77,13 +65,10 @@ def _ms_bfs_with_paths(intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrix
                     s_to = intersection.state_of_index[j]
                     edge_usage.append((s_from, sym, s_to))
 
-    #print(reachability.toarray() * 1)
     rows, cols = reachability.nonzero()
     for i, j in zip(rows, cols):
         s = intersection.state_of_index.get(i)
         f = intersection.state_of_index.get(j)
-        #print(f"{s} {f}")
-    #print(f"edge_usage is {edge_usage}")
 
     return reachability, edge_usage
 
@@ -104,22 +89,15 @@ def _add_nonterms(reachability: scsp.spmatrix, adj_graph: AdjacencyMatrixFA, adj
     for i, j in zip(rows, cols):
         gr_start, rsm_start = intersection.state_of_index.get(i).value
         gr_fin, rsm_fin = intersection.state_of_index.get(j).value
-        #print(f"{gr_start} {rsm_start} {gr_fin} {rsm_fin}")
         start_rsm_box, _ = rsm_start.value
         fin_rsm_box, _ = rsm_fin.value
         if start_rsm_box == fin_rsm_box and rsm_start in adj_rsm.start_states and rsm_fin in adj_rsm.final_states:
-            #print(f"{gr_start} {rsm_start} {gr_fin} {rsm_fin}")
-            '''
-            if ((gr_start, rsm_start), start_rsm_box, (gr_fin, rsm_fin)) not in edges:
-                print("IM NOT HERE")
-                continue'''
             if not start_rsm_box in adj_graph.boolean_decompress:
                 n = len(adj_graph.states)
                 matrix_ctor = getattr(scsp, f"{adj_graph.matrix_format}_matrix", scsp.csr_matrix)
                 new_nonterm_added = True
                 nonterm_mat = matrix_ctor((n, n), dtype=bool)
                 nonterm_mat[adj_graph.index_of_state.get(gr_start), adj_graph.index_of_state.get(gr_fin)] = True
-                #print(f" I PUT THIS IN MAT {gr_start} {rsm_start} {gr_fin} {rsm_fin}")
                 adj_graph.boolean_decompress.update({start_rsm_box: nonterm_mat})
                 adj_graph.labels.add(start_rsm_box)
             else:
@@ -127,7 +105,6 @@ def _add_nonterms(reachability: scsp.spmatrix, adj_graph: AdjacencyMatrixFA, adj
                 if not nonterm_mat[adj_graph.index_of_state.get(gr_start), adj_graph.index_of_state.get(gr_fin)]:
                     new_nonterm_added = True
                     nonterm_mat[adj_graph.index_of_state.get(gr_start), adj_graph.index_of_state.get(gr_fin)] = True
-                    #print(f" I PUT THIS IN MAT {gr_start} {rsm_start} {gr_fin} {rsm_fin}")
                     adj_graph.boolean_decompress.update({start_rsm_box: nonterm_mat})
     return (adj_graph, new_nonterm_added)
 
@@ -143,55 +120,23 @@ def tensor_based_cfpq(
   matrix_format="csr",
 ) -> set[tuple[int, int]]:
     matrix_ctor = getattr(scsp, f"{matrix_format}_matrix", scsp.csr_matrix)
-    # maybe change it to "if start_nodes is None or s in start_nodes" in last if?
     if start_nodes is None:
         start_nodes = graph.nodes
     if final_nodes is None:
         final_nodes = graph.nodes
 
-    # add nullable symbols into graph
-    '''for sym in rsm.boxes:
-        box: Box = rsm.get_box(sym)
-        if box.start_state.issubset(box.final_states):
-            print(f"{sym} IS NULL")
-            for node in graph.nodes:
-                graph.add_edge(node, node, label=sym)'''
-
     fa_graph = graph_to_nfa(graph, start_nodes, final_nodes)
     adj_graph = AdjacencyMatrixFA(fa_graph, matrix_format=matrix_format)
-    #print("BOOL DEC BEFORE ALGO")
-    #adj_graph._print_boolean_decompress_pretty()
     fa_rsm = _build_rsm_fa(rsm)
-    #print(fa_rsm._transition_function.to_dict())
     adj_rsm = AdjacencyMatrixFA(fa_rsm, matrix_format=matrix_format)
-    #print(adj_rsm.start_states)
-    #print(adj_rsm.final_states)
 
 
     info_added = True
     while info_added:
         info_added = False
         intersection = intersect_automata(adj_graph, adj_rsm)
-        #print(adj_rsm.labels)
-        #print(intersection.labels)
-        #intersection._print_boolean_decompress_pretty()
         reachability, edges_reachable_from_start = _ms_bfs_with_paths(intersection, adj_rsm)
         adj_graph, info_added = _add_nonterms(reachability, adj_graph, adj_rsm, intersection, edges_reachable_from_start)
-        #adj_graph._print_boolean_decompress_pretty()
-        #adj_graph._print_boolean_decompress_pretty()
-        #print(edges_reachable_from_start)
-        '''for fst, lbl, snd in edges_reachable_from_start:
-            bool_dec_mat = adj_graph.boolean_decompress.get(lbl)
-            fst_gr, _ = fst.value
-            snd_gr, _ = snd.value
-            if not bool_dec_mat[adj_graph.index_of_state.get(fst_gr), adj_graph.index_of_state.get(snd_gr)]:
-                # TODO: on  example, maybe S shouldnt be there?
-                # TODO: maybe check if all vertices are in start->end path?
-                #print(f"{fst} {lbl} {snd}")
-                bool_dec_mat[adj_graph.index_of_state.get(fst_gr), adj_graph.index_of_state.get(snd_gr)] = True
-                info_added = True'''
-
-
 
     res = set()
     if rsm.initial_label in adj_graph.boolean_decompress:
@@ -202,101 +147,4 @@ def tensor_based_cfpq(
             f = adj_graph.state_of_index.get(j)
             if (s in start_nodes) and (f in final_nodes):
                 res.add((s, f))
-    #print(f"res is {res}")
     return res
-
-
-
-
-
-
-'''
-cfg = CFG.from_text("S -> a S b | a b")
-baa_graph = MultiDiGraph()
-baa_graph.add_edges_from(
-    [(0, 0, {"label": "b"}), (0, 1, {"label": "a"}), (1, 0, {"label": "a"})]
-)
-res = cfg_to_rsm(cfg)
-
-res_tensor = tensor_based_cfpq(res, baa_graph)
-print(res_tensor)
-
-box: Box = res.get_box("S")
-edges = box.dfa.minimize().to_networkx().edges(data="label")
-s_graph = box.dfa.minimize().to_networkx()
-
-edge_labels = defaultdict(list)
-for u, v, data in s_graph.edges(data=True):
-    if 'label' in data:
-        edge_labels[(u, v)].append(data['label'])
-edge_labels_combined = {}
-for (u, v), labels in edge_labels.items():
-    edge_labels_combined[(u, v)] = ', '.join(map(str, labels))
-pos = nx.spring_layout(s_graph)
-plt.figure(figsize=(12, 8))
-nx.draw(s_graph, pos, with_labels=True,
-        node_color='lightblue',
-        node_size=500,
-        font_size=10,
-        font_weight='bold',
-        arrows=True,
-        edge_color='gray')
-nx.draw_networkx_edge_labels(s_graph, pos, edge_labels=edge_labels_combined)
-plt.show()
-'''
-
-'''
-# Creation of variables
-var_S = Variable("S")
-
-# Creation of terminals
-ter_a = Terminal("a")
-ter_b = Terminal("b")
-eps = Epsilon()
-
-# Creation of productions
-p0 = Production(var_S, [eps])
-p1 = Production(var_S, [ter_a, var_S, ter_b])
-p2 = Production(var_S, [var_S, var_S])
-
-
-# Creation of the CFG
-cfg = CFG(
-    {var_S}, {ter_a, ter_b}, var_S, {p0, p1, p2}
-)
-#print(cfg.to_text())
-
-# Creation of graph
-graph = nx.MultiDiGraph()
-graph.add_edge(1, 0, label="a")  # 1 -a-> 0
-graph.add_edge(0, 1, label="a")  # 0 -a-> 1
-graph.add_edge(0, 0, label="b")  # 0 -b-> 0
-
-res = cfg_to_rsm(cfg)
-
-res_tensor = tensor_based_cfpq(res, graph, {1}, {0, 1})
-print(res_tensor)
-
-box: Box = res.get_box(var_S)
-edges = box.dfa.minimize().to_networkx().edges(data="label")
-s_graph = box.dfa.minimize().to_networkx()
-
-edge_labels = defaultdict(list)
-for u, v, data in s_graph.edges(data=True):
-    if 'label' in data:
-        edge_labels[(u, v)].append(data['label'])
-edge_labels_combined = {}
-for (u, v), labels in edge_labels.items():
-    edge_labels_combined[(u, v)] = ', '.join(map(str, labels))
-pos = nx.spring_layout(s_graph)
-plt.figure(figsize=(12, 8))
-nx.draw(s_graph, pos, with_labels=True,
-        node_color='lightblue',
-        node_size=500,
-        font_size=10,
-        font_weight='bold',
-        arrows=True,
-        edge_color='gray')
-nx.draw_networkx_edge_labels(s_graph, pos, edge_labels=edge_labels_combined)
-plt.show()
-'''

--- a/project/task8.py
+++ b/project/task8.py
@@ -45,7 +45,6 @@ def _ms_bfs_with_paths(intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrix
         rows, cols = mat.nonzero()
         for i, j in zip(rows, cols):
             s = intersection.state_of_index.get(i)
-            f = intersection.state_of_index.get(j)
 
     reachability = matrix_ctor((n, n), dtype=bool)
     start_st = _define_start_states(intersection, adj_rsm)
@@ -111,7 +110,7 @@ def _add_nonterms(
             and rsm_start in adj_rsm.start_states
             and rsm_fin in adj_rsm.final_states
         ):
-            if not start_rsm_box in adj_graph.boolean_decompress:
+            if start_rsm_box not in adj_graph.boolean_decompress:
                 n = len(adj_graph.states)
                 matrix_ctor = getattr(
                     scsp, f"{adj_graph.matrix_format}_matrix", scsp.csr_matrix
@@ -146,7 +145,6 @@ def tensor_based_cfpq(
     final_nodes: set[int] = None,
     matrix_format="csr",
 ) -> set[tuple[int, int]]:
-    matrix_ctor = getattr(scsp, f"{matrix_format}_matrix", scsp.csr_matrix)
     if start_nodes is None:
         start_nodes = graph.nodes
     if final_nodes is None:

--- a/project/task8.py
+++ b/project/task8.py
@@ -73,7 +73,6 @@ def _ms_bfs_with_paths(intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrix
     rows, cols = reachability.nonzero()
     for i, j in zip(rows, cols):
         s = intersection.state_of_index.get(i)
-        f = intersection.state_of_index.get(j)
 
     return reachability, edge_usage
 

--- a/project/task8.py
+++ b/project/task8.py
@@ -40,19 +40,12 @@ def _ms_bfs_with_paths(intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrix
     matrix_ctor = getattr(scsp, f"{intersection.matrix_format}_matrix", scsp.csr_matrix)
 
     bool_dec = intersection.boolean_decompress
-    for sym in bool_dec:
-        mat = bool_dec.get(sym)
-        rows, cols = mat.nonzero()
-        for i, j in zip(rows, cols):
-            s = intersection.state_of_index.get(i)
 
     reachability = matrix_ctor((n, n), dtype=bool)
     start_st = _define_start_states(intersection, adj_rsm)
     for s in start_st:
         i = intersection.index_of_state[s]
         reachability[i, i] = True
-
-    edge_usage = []
 
     finished = False
     while not finished:
@@ -64,17 +57,7 @@ def _ms_bfs_with_paths(intersection: AdjacencyMatrixFA, adj_rsm: AdjacencyMatrix
                 reachability = reachability + sym_reach
                 finished = False
 
-                rows, cols = new_edges.nonzero()
-                for i, j in zip(rows, cols):
-                    s_from = intersection.state_of_index[i]
-                    s_to = intersection.state_of_index[j]
-                    edge_usage.append((s_from, sym, s_to))
-
-    rows, cols = reachability.nonzero()
-    for i, j in zip(rows, cols):
-        s = intersection.state_of_index.get(i)
-
-    return reachability, edge_usage
+    return reachability
 
 
 # MSBFS should search all paths from RSM-start to RSM-fin, regardless of graph start and end vertices
@@ -95,7 +78,6 @@ def _add_nonterms(
     adj_graph: AdjacencyMatrixFA,
     adj_rsm: AdjacencyMatrixFA,
     intersection: AdjacencyMatrixFA,
-    edges,
 ) -> tuple[AdjacencyMatrixFA, bool]:
     new_nonterm_added = False
     rows, cols = reachability.nonzero()
@@ -144,11 +126,6 @@ def tensor_based_cfpq(
     final_nodes: set[int] = None,
     matrix_format="csr",
 ) -> set[tuple[int, int]]:
-    if start_nodes is None:
-        start_nodes = graph.nodes
-    if final_nodes is None:
-        final_nodes = graph.nodes
-
     fa_graph = graph_to_nfa(graph, start_nodes, final_nodes)
     adj_graph = AdjacencyMatrixFA(fa_graph, matrix_format=matrix_format)
     fa_rsm = _build_rsm_fa(rsm)
@@ -158,11 +135,9 @@ def tensor_based_cfpq(
     while info_added:
         info_added = False
         intersection = intersect_automata(adj_graph, adj_rsm)
-        reachability, edges_reachable_from_start = _ms_bfs_with_paths(
-            intersection, adj_rsm
-        )
+        reachability = _ms_bfs_with_paths(intersection, adj_rsm)
         adj_graph, info_added = _add_nonterms(
-            reachability, adj_graph, adj_rsm, intersection, edges_reachable_from_start
+            reachability, adj_graph, adj_rsm, intersection
         )
 
     res = set()
@@ -172,6 +147,8 @@ def tensor_based_cfpq(
         for i, j in zip(rows, cols):
             s = adj_graph.state_of_index.get(i)
             f = adj_graph.state_of_index.get(j)
-            if (s in start_nodes) and (f in final_nodes):
+            if (not start_nodes or s in start_nodes) and (
+                not final_nodes or f in final_nodes
+            ):
                 res.add((s, f))
     return res

--- a/project/task9.py
+++ b/project/task9.py
@@ -1,0 +1,171 @@
+from pyformlang.finite_automaton import State, Symbol
+from pyformlang.rsa import RecursiveAutomaton
+import networkx as nx
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class BoxState:
+    box: Symbol
+    state: State
+
+
+@dataclass(frozen=True)
+class Descriptor:
+    vertex: int
+    box_state: BoxState
+    frame: "StackFrame"
+
+
+class StackFrame:
+    box_state: BoxState
+    graph_node: int
+    edges: dict[BoxState, set["StackFrame"]]
+    visited_vertices: set[int]
+
+    def __init__(self, box_state: BoxState, graph_node: int):
+        self.box_state = box_state
+        self.graph_node = graph_node
+        self.edges = {}
+        self.visited_vertices = set()
+
+
+def link_frames(frame: StackFrame, edge_state: BoxState, parent_frame: StackFrame) -> set[Descriptor]:
+    bucket = frame.edges.setdefault(edge_state, set())
+    if parent_frame in bucket:
+        return set()
+    bucket.add(parent_frame)
+    return {Descriptor(n, edge_state, parent_frame) for n in frame.visited_vertices}
+
+
+def pop(frame: StackFrame, node: int) -> set[Descriptor]:
+    if node in frame.visited_vertices:
+        return set()
+    frame.visited_vertices.add(node)
+    result = set()
+    for box_state, frames in frame.edges.items():
+        for frame in frames:
+            result.add(Descriptor(node, box_state, frame))
+    return result
+
+
+@dataclass
+class BoxTransitions:
+    # represents terminal and the following state of box after it is parsed
+    terminals: dict[str, BoxState] = field(default_factory=dict)
+    # tuple represents the pair of start state of inner box and the following state of outer box after nonterm will be parsed
+    nonterminals: dict[str, tuple[BoxState, BoxState]] = field(default_factory=dict)
+    is_final: bool = False
+
+
+class GLLContext:
+    graph: nx.DiGraph
+    graph_edges: dict[int, dict[str, set[int]]]
+    stack_frames: dict[tuple[BoxState, int], StackFrame]
+    start_state: BoxState
+    fin_frame: StackFrame
+    processing_queue: set[Descriptor] #doesn't really need to be strictly queue because the order of descriptors processing is arbitrary
+    visited: set[Descriptor]
+    result: set[tuple[int, int]]
+
+    def __init__(self, rsm: RecursiveAutomaton, graph: nx.DiGraph):
+        self.graph = graph
+        self.stack_frames = {}
+        self.start_state = BoxState(
+            rsm.initial_label,
+            rsm.boxes[rsm.initial_label].dfa.start_state.value
+        )
+        self.fin_frame = StackFrame(BoxState(Symbol("$"), State("fin")), -1)
+        self.processing_queue = set()
+        self.visited = set()
+        self.result = set()
+
+
+        self.graph_edges = {}
+        for fst, snd, lbl in graph.edges(data="label"):
+            self.graph_edges.setdefault(fst, {}).setdefault(lbl, set()).add(snd)
+
+
+        self.rsm_data = {}
+        for sym, box in rsm.boxes.items():
+            data = {}
+            graph_box = box.dfa.to_networkx()
+            for state in graph_box.nodes:
+                data[state] = BoxTransitions(is_final=(state in box.dfa.final_states))
+            for fst, snd, lbl in graph_box.edges(data="label"):
+                #print(f"i have label {lbl}")
+                if Symbol(lbl) not in rsm.boxes:
+                    data[fst].terminals[lbl] = BoxState(sym, snd)
+                else:
+                    # if lbl is nonterm, find start state of its box
+                    start_of_inner_box = rsm.boxes[Symbol(lbl)].dfa.start_state.value
+                    data[fst].nonterminals[lbl] = (
+                        BoxState(Symbol(lbl), start_of_inner_box),
+                        BoxState(sym, snd),
+                    )
+            self.rsm_data[sym] = data
+
+
+def create_stack_frame(gll: GLLContext, st: BoxState, node: int) -> StackFrame:
+    key = (st, node)
+    if key not in gll.stack_frames:
+        gll.stack_frames[key] = StackFrame(st, node)
+    return gll.stack_frames[key]
+
+
+def push_new_descriptors(gll: GLLContext, items: set[Descriptor]):
+    fresh = set(items) - gll.visited
+    gll.visited |= fresh
+    gll.processing_queue |= fresh
+
+
+def handle_popped(gll: GLLContext, popped: set[Descriptor], prev: Descriptor):
+    for desc in popped:
+        if desc.frame is gll.fin_frame:
+            gll.result.add((prev.frame.graph_node, desc.vertex))
+        else:
+            push_new_descriptors(gll, {desc})
+
+
+def gll_based_cfpq(
+    rsm: RecursiveAutomaton,
+    graph: nx.DiGraph,
+    start_nodes: set[int] = None,
+    final_nodes: set[int] = None,
+) -> set[tuple[int, int]]:
+
+    gll = GLLContext(rsm, graph)
+    if not start_nodes:
+        start_nodes = graph.nodes()
+    if not final_nodes:
+        final_nodes = graph.nodes()
+
+    # create start configs and link them to final frame via service state. push all start descriptors into queue
+    for start_node in start_nodes:
+        frame = create_stack_frame(gll, gll.start_state, start_node)
+        link_frames(frame, BoxState(Symbol("$"), State("fin")), gll.fin_frame)
+        push_new_descriptors(gll, {Descriptor(start_node, gll.start_state, frame)})
+
+    while gll.processing_queue:
+        cur_desc = gll.processing_queue.pop()
+        node, state, frame = cur_desc.vertex, cur_desc.box_state, cur_desc.frame
+        rsm_info = gll.rsm_data[state.box][state.state]
+
+        # case 1: terminal transitions
+        for term, to_state in rsm_info.terminals.items():
+            for nxt in gll.graph_edges.get(node, {}).get(term, ()):
+                push_new_descriptors(gll, {Descriptor(nxt, to_state, frame)})
+
+        # case 2: nonterminal transitions
+        for _, (inner_start_state, return_state) in rsm_info.nonterminals.items():
+            new_frame = create_stack_frame(gll, inner_start_state, node)
+            popped = link_frames(new_frame, return_state, frame)
+            handle_popped(gll, popped, cur_desc)
+            push_new_descriptors(gll, {Descriptor(node, inner_start_state, new_frame)})
+
+        # case 3: final state of current box
+        if rsm_info.is_final:
+            popped = pop(frame, node)
+            handle_popped(gll, popped, cur_desc)
+
+    return {(fst, snd) for (fst, snd) in gll.result if snd in final_nodes}

--- a/project/task9.py
+++ b/project/task9.py
@@ -30,7 +30,9 @@ class StackFrame:
         self.visited_vertices = set()
 
 
-def link_frames(frame: StackFrame, edge_state: BoxState, parent_frame: StackFrame) -> set[Descriptor]:
+def link_frames(
+    frame: StackFrame, edge_state: BoxState, parent_frame: StackFrame
+) -> set[Descriptor]:
     bucket = frame.edges.setdefault(edge_state, set())
     if parent_frame in bucket:
         return set()
@@ -64,7 +66,9 @@ class GLLContext:
     stack_frames: dict[tuple[BoxState, int], StackFrame]
     start_state: BoxState
     fin_frame: StackFrame
-    processing_queue: set[Descriptor] #doesn't really need to be strictly queue because the order of descriptors processing is arbitrary
+    processing_queue: set[
+        Descriptor
+    ]  # doesn't really need to be strictly queue because the order of descriptors processing is arbitrary
     visited: set[Descriptor]
     result: set[tuple[int, int]]
 
@@ -72,19 +76,16 @@ class GLLContext:
         self.graph = graph
         self.stack_frames = {}
         self.start_state = BoxState(
-            rsm.initial_label,
-            rsm.boxes[rsm.initial_label].dfa.start_state.value
+            rsm.initial_label, rsm.boxes[rsm.initial_label].dfa.start_state.value
         )
         self.fin_frame = StackFrame(BoxState(Symbol("$"), State("fin")), -1)
         self.processing_queue = set()
         self.visited = set()
         self.result = set()
 
-
         self.graph_edges = {}
         for fst, snd, lbl in graph.edges(data="label"):
             self.graph_edges.setdefault(fst, {}).setdefault(lbl, set()).add(snd)
-
 
         self.rsm_data = {}
         for sym, box in rsm.boxes.items():
@@ -93,7 +94,7 @@ class GLLContext:
             for state in graph_box.nodes:
                 data[state] = BoxTransitions(is_final=(state in box.dfa.final_states))
             for fst, snd, lbl in graph_box.edges(data="label"):
-                #print(f"i have label {lbl}")
+                # print(f"i have label {lbl}")
                 if Symbol(lbl) not in rsm.boxes:
                     data[fst].terminals[lbl] = BoxState(sym, snd)
                 else:
@@ -133,7 +134,6 @@ def gll_based_cfpq(
     start_nodes: set[int] = None,
     final_nodes: set[int] = None,
 ) -> set[tuple[int, int]]:
-
     gll = GLLContext(rsm, graph)
     if not start_nodes:
         start_nodes = graph.nodes()


### PR DESCRIPTION
 Implemented a function based on the Generalized LL algorithm that solves the reachability problem between all pairs of vertices for a given graph and a given context-free grammar: 
`def gll_based_cfpq(
      rsm: pyformlang.rsa.RecursiveAutomaton,
      graph: nx.DiGraph,
      start_nodes: set[int] = None,
      final_nodes: set[int] = None,
  ) -> set[tuple[int, int]]:
  pass`